### PR TITLE
Fix raster embedding and cleanup

### DIFF
--- a/R/dml.R
+++ b/R/dml.R
@@ -18,7 +18,7 @@ dml <- function(code, ggobj = NULL, layout = "default",
   out <- list()
   out$code <- substitute(code)
   out$ggobj <- ggobj
-  if (!(layout %in% c("default", "left_col", "right_col", "full_slide") ||
+  if (!(all(layout %in% c("default", "left_col", "right_col", "full_slide")) ||
         (inherits(layout, "list") &&
          setequal(names(layout), c("width", "height", "left", "top"))))) {
     stop("Invalid layout value")
@@ -84,7 +84,9 @@ knit_print.dml <- function(x, ...) {
     rast_element <- xml_find_all(dml_xml, "//p:pic/p:blipFill/a:blip")
     raster_files <- list_raster_files(img_dir = img_directory )
     raster_id <- xml_attr(rast_element, "embed")
-    xml_attr(rast_element, "r:embed") <- raster_files
+    for (i in seq_along(raster_files)) {
+      xml_attr(rast_element[i], "r:embed") <- raster_files[i]
+    }
   }
   dml_str <- paste(
     as.character(xml_find_first(dml_xml, "//p:grpSp")),

--- a/R/rpptx_document.R
+++ b/R/rpptx_document.R
@@ -19,8 +19,10 @@ rpptx_document <- function(...) {
       is_hacked <- grepl( "\\.png$", xml_attr(blips, "embed") )
       blips <- blips[is_hacked]
       imgs <- xml_attr(blips, "embed")[is_hacked]
-      for( img in imgs )
+      for( img in imgs ) {
         slide$reference_img(src = img, dir_name = file.path(x$package_dir, "ppt/media"))
+        if(clean) file.remove(img)
+      }
       rel_df <- slide$rel_df()
       rids <- rel_df$id[match( imgs, rel_df$ext_src)]
       for( rid in seq_along(rids) ){


### PR DESCRIPTION
Rasters were being indexed incorrectly previously, with the first raster being assigned to all elements.  This fixes this and also cleans up rasters after rendering.